### PR TITLE
feat: use latest image for bee containers and pull option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ $ npm install -g @fairdatasociety/fdp-play
 ## Usage
 
 ```shell
-# This spins up the cluster for specific Bee version and exits
-$ fdp-play start --detach 1.6.1
+# Listing of available commands and print help menu
+$ fdp-play --help
 
-# The spins up the cluster using Bee version configured in external places. See bellow for options where to place it.
+# The spins up the cluster using the latest supported Bee version.
 $ fdp-play start --detach
+
+# This spins up the cluster for specific Bee version and exits
+$ fdp-play start -d --bee-version 1.6.1
+
+# This will clean the containers before start (fresh) and tries to pull the latest images from the Docker repository (pull)
+$ fdp-play start --pull --fresh
 
 # The spins up the cluster using specific blockchain image.
 # NOTE: The fairdatasociety/fdp-play-blockchain is the base blockchain image that only contains pre-funded accounts for Bee nodes.
@@ -47,29 +53,15 @@ $ fdp-play stop
 
 # You can also spin up the cluster without the --detach which then directly
 # attaches to the Queen logs and the cluster is terminated upon SIGINT (Ctrl+C)
-$ fdp-play start 1.6.1
+$ fdp-play start
 ```
 
 For more details see the `--help` page of the CLI and its commands.
 
-### External Bee version configuration
-
-You can omit the Bee version argument when running `fdp-play start` command if you specify it in one of the expected places:
-
- - `package.json` placed in current working directory (cwd) under the `engines.bee` property.
- - `.beefactory.json` placed in current working directory (cwd) with property `version`.
-
 ### Docker Images
 
 Bee Factory as the NPM package that you can install, like mentioned above, works in a way that it orchestrates launching FDP Play Docker images
-in correct order and awaits for certain initializations to happen in correct form. These Docker images are automatically built with our CI
-upon every new Bee release, so you can just specify which version you want to run (starting with `1.6.1` version) as part of the `start` command.
-
-#### Latest versions
-
-There is special Bee Factory image tag `latest` that has the latest Bee's master build.
-It is not recommended using this tag unless you need to test some upcoming feature and know what are you doing.
-There is high chance that there might be some change in Bee that is not compatible with current Bee Factory and so it might not even work.
+in correct order and awaits for certain initializations to happen in correct form.
 
 ## Contribute
 

--- a/src/utils/config-sources.ts
+++ b/src/utils/config-sources.ts
@@ -1,5 +1,4 @@
 import { readFile as readFileCb } from 'fs'
-import * as path from 'path'
 import { promisify } from 'util'
 
 const readFile = promisify(readFileCb)
@@ -16,44 +15,4 @@ export function stripCommit(version: string): string {
 
   // If the version contains commit ==> hash remove it
   return version.replace('-stateful', '').replace(/-[0-9a-fA-F]{8}$/, '')
-}
-
-async function searchPackageJson(): Promise<string | undefined> {
-  const expectedPath = path.join(process.cwd(), 'package.json')
-
-  try {
-    const pkgJson = JSON.parse(await readFile(expectedPath, { encoding: 'utf8' }))
-
-    return pkgJson?.engines?.bee
-  } catch (e) {
-    return undefined
-  }
-}
-
-async function searchBeeFactory(): Promise<string | undefined> {
-  const expectedPath = path.join(process.cwd(), '.beefactory.json')
-
-  try {
-    const pkgJson = JSON.parse(await readFile(expectedPath, { encoding: 'utf8' }))
-
-    return pkgJson?.version
-  } catch (e) {
-    return undefined
-  }
-}
-
-export async function findBeeVersion(): Promise<string> {
-  const packageJson = await searchPackageJson()
-
-  if (packageJson) {
-    return packageJson
-  }
-
-  const beeFactory = await searchBeeFactory()
-
-  if (beeFactory) {
-    return beeFactory
-  }
-
-  throw new Error('Bee Version was not specified nor it is present in expected external places!')
 }


### PR DESCRIPTION
This PR introduces the `--pull` flag, that pulls the used Docker images from the Docker repository before starting containers.
It is useful if the `latest` tag is used for images and those are intended to be upgraded to the most recent version live in the [Docker repository](https://hub.docker.com/orgs/fairdatasociety/repositories).

With this change, the default Bee image has been also changed to use the `latest` tag as there is option to easily fetch for new Bee version updates under this tag in need.