### PR TITLE
feat: without bees

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ $ fdp-play start --detach
 # This spins up the cluster for specific Bee version and exits
 $ fdp-play start -d --bee-version 1.6.1
 
+# This spins up the environment without Bee nodes
+$ fdp-play start --without-bees
+
 # This will clean the containers before start (fresh) and tries to pull the latest images from the Docker repository (pull)
 $ fdp-play start --pull --fresh
 

--- a/test/integration/start.spec.ts
+++ b/test/integration/start.spec.ts
@@ -64,6 +64,27 @@ describe('start command', () => {
     }),
   )
 
+  describe('should start cluster without bee nodes', () => {
+    beforeAll(async () => {
+      await run(['stop', '--rm']) // Cleanup the testing containers
+    })
+
+    it(
+      '',
+      wrapper(async () => {
+        // As spinning the cluster with --detach the command will exit once the cluster is up and running
+        await run(['start', '--without-bees'])
+
+        await expect(findContainer(docker, 'blockchain')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'queen')).rejects.toHaveProperty('statusCode', 404)
+        await expect(findContainer(docker, 'worker-1')).rejects.toHaveProperty('statusCode', 404)
+        await expect(findContainer(docker, 'worker-2')).rejects.toHaveProperty('statusCode', 404)
+        await expect(findContainer(docker, 'worker-3')).rejects.toHaveProperty('statusCode', 404)
+        await expect(findContainer(docker, 'worker-4')).rejects.toHaveProperty('statusCode', 404)
+      }),
+    )
+  })
+
   describe('should start cluster with just few workers', () => {
     beforeAll(async () => {
       await run(['stop', '--rm']) // Cleanup the testing containers


### PR DESCRIPTION
add `without-bees` flag to `start` command in order to start the environment without Bee nodes.

This can be useful when the application development only has some blockchain related dependency, but that is not related to Bee clients.