### PR TITLE
feat: fairos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ $ fdp-play start -d --bee-version 1.6.1
 # This spins up the environment without Bee nodes
 $ fdp-play start --without-bees
 
+# Or start a fairOS instance that will use the Queen Bee node.
+$ fdp-play start --fairos
+
 # This will clean the containers before start (fresh) and tries to pull the latest images from the Docker repository (pull)
 $ fdp-play start --pull --fresh
 

--- a/src/command/start.ts
+++ b/src/command/start.ts
@@ -12,7 +12,7 @@ import { waitForBlockchain, waitForQueen, waitForWorkers } from '../utils/wait'
 import ora from 'ora'
 import { VerbosityLevel } from './root-command/logging'
 import { stripCommit } from '../utils/config-sources'
-import { DEFAULT_BLOCKCHAIN_IMAGE, ENV_ENV_PREFIX_KEY } from '../constants'
+import { DEFAULT_BLOCKCHAIN_IMAGE, DEFAULT_FAIROS_IMAGE, ENV_ENV_PREFIX_KEY } from '../constants'
 
 const DEFAULT_BEE_REPO = 'fairdatasociety'
 const ENV_IMAGE_PREFIX_KEY = 'FDP_PLAY_IMAGE_PREFIX'
@@ -121,6 +121,9 @@ export class Start extends RootCommand implements LeafCommand {
   })
   public fairos!: boolean
 
+  @Option({ key: 'fairos-image', description: 'FairOS Docker image', required: false, default: DEFAULT_FAIROS_IMAGE })
+  public fairosImage!: string
+
   public async run(): Promise<void> {
     await super.init()
 
@@ -142,6 +145,7 @@ export class Start extends RootCommand implements LeafCommand {
       beeImagePrefix: this.beeImagePrefix,
       blockchainImageName: this.blockchainImageName,
       beeRepo: this.beeRepo,
+      fairOsImage: this.fairosImage,
     })
     const status = await docker.getAllStatus()
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,4 +4,5 @@
  */
 export const DEFAULT_BLOCKCHAIN_IMAGE = 'fairdatasociety/fdp-contracts-blockchain'
 export const DEFAULT_BLOCKCHAIN_CONTAINER = 'fdp-play-blockchain'
+export const DEFAULT_FAIROS_IMAGE = 'fairdatasociety/fairos-dfs:v0.7.3'
 export const ENV_ENV_PREFIX_KEY = 'FDP_PLAY_ENV_PREFIX'

--- a/src/utils/config-sources.ts
+++ b/src/utils/config-sources.ts
@@ -1,7 +1,3 @@
-import { readFile as readFileCb } from 'fs'
-import { promisify } from 'util'
-
-const readFile = promisify(readFileCb)
 const VERSION_REGEX = /^\d\.\d\.\d(-\w+)*$/
 
 export function stripCommit(version: string): string {

--- a/test/integration/start.spec.ts
+++ b/test/integration/start.spec.ts
@@ -85,6 +85,27 @@ describe('start command', () => {
     )
   })
 
+  describe('should start cluster with fairos node', () => {
+    beforeAll(async () => {
+      await run(['stop', '--rm']) // Cleanup the testing containers
+    })
+
+    it(
+      '',
+      wrapper(async () => {
+        // As spinning the cluster with --detach the command will exit once the cluster is up and running
+        await run(['start', '--fairos'])
+
+        await expect(findContainer(docker, 'blockchain')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'worker-1')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'worker-2')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'worker-3')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'worker-4')).resolves.toBeDefined()
+        await expect(findContainer(docker, 'fairos')).resolves.toBeDefined()
+      }),
+    )
+  })
+
   describe('should start cluster with just few workers', () => {
     beforeAll(async () => {
       await run(['stop', '--rm']) // Cleanup the testing containers


### PR DESCRIPTION
add `--fairos` flag to the `start` command in order to spin up [FairOS-DFS](https://github.com/fairdatasociety/fairos-dfs) instance in the environment.
add option `--fairos-image` as well so that user can change the base supported FairOS image.

The default FairOS version is the 0.7.3, as the new versions of FairOS cannot handle the new ENS contracts yet.