### PR TITLE
fix: node 18 error

### DIFF
--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -27,9 +27,9 @@ function isAllowedError(e: FetchError): boolean {
     return true
   }
 
-  // Error when requesting from node 18 to bee node (1.11.1).
+  // Error when requesting from Node 18 to bee node (1.11.1).
   // Happens in `beeDebug.getNodeAddresses()` method.
-  // It looks like the bee node sends a response with a missing header, or the response is processed incorrectly/
+  // It looks like the bee node sends a response with a missing header, or the response is processed incorrectly.
   if (e.message.includes('other side closed')) {
     return true
   }

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -27,6 +27,13 @@ function isAllowedError(e: FetchError): boolean {
     return true
   }
 
+  // Error when requesting from node 18 to bee node (1.11.1).
+  // Happens in `beeDebug.getNodeAddresses()` method.
+  // It looks like the bee node sends a response with a missing header, or the response is processed incorrectly/
+  if (e.message.includes('other side closed')) {
+    return true
+  }
+
   return ALLOWED_ERRORS.some(substring => e.message.includes(substring))
 }
 


### PR DESCRIPTION
The error occurs when requesting from Node 18 to a bee node (1.11.1) using the beeDebug.getNodeAddresses() method.
It looks like the bee node sends a response with a missing header, or the response is processed incorrectly.

Also, the error disappears if you use the '--no-experimental-fetch' flag for Node 18. Because Node 18 introduced its own fetch, it seems that node-fetch uses this built-in fetch and therefore we get different behavior on different versions of the node.

Some information about the bug: https://github.com/nodejs/undici/issues/583

Close https://github.com/fairDataSociety/fdp-play/issues/91