### PR TITLE
feat: bee 2.2

### DIFF
--- a/orchestrator/builder/environment.sh
+++ b/orchestrator/builder/environment.sh
@@ -16,9 +16,9 @@ PARAMETERS:
     --workers=number            all Bee nodes in the test environment. Default is 4.
     --detach                    It will not log the output of Queen node at the end of the process.
     --port-maps=number          map ports of the cluster nodes to the hosting machine in the following manner:
-                                1. 1633:1635
-                                2. 11633:11635
-                                3. 21633:21635 (...)
+                                1. 1633:1634
+                                2. 11633:11634
+                                3. 21633:21634 (...)
                                 number represents the nodes number to map from. Default is 2.
     --hostname=string           Interface to which should the nodes be bound (default 127.0.0.0).
 USAGE

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -240,7 +240,6 @@ export class Docker {
         ExposedPorts: {
           '1633/tcp': {},
           '1634/tcp': {},
-          '1635/tcp': {},
         },
         Tty: true,
         Cmd: ['start'],
@@ -252,7 +251,6 @@ export class Docker {
           PortBindings: {
             '1633/tcp': [{ HostPort: '1633' }],
             '1634/tcp': [{ HostPort: '1634' }],
-            '1635/tcp': [{ HostPort: '1635' }],
           },
         },
       },
@@ -287,7 +285,6 @@ export class Docker {
         ExposedPorts: {
           '1633/tcp': {},
           '1634/tcp': {},
-          '1635/tcp': {},
         },
         Cmd: ['start'],
         Env: this.createBeeEnvParameters(queenAddress),
@@ -298,7 +295,6 @@ export class Docker {
           PortBindings: {
             '1633/tcp': [{ HostPort: (1633 + workerNumber * 10000).toString() }],
             '1634/tcp': [{ HostPort: (1634 + workerNumber * 10000).toString() }],
-            '1635/tcp': [{ HostPort: (1635 + workerNumber * 10000).toString() }],
           },
         },
       },
@@ -544,7 +540,6 @@ export class Docker {
     const corsOrigins = '*'
     const cookieDomain = 'localhost'
     const beeApiUrl = `http://${this.queenName}:1633`
-    const beeDebugApiUrl = `http://${this.queenName}:1635`
 
     return [
       `--postageBlockId=${batchId}`,
@@ -557,7 +552,7 @@ export class Docker {
   }
 
   private async createPostageBatch(): Promise<string> {
-    const beeDebug = new BeeDebug('http://localhost:1635')
+    const beeDebug = new BeeDebug('http://localhost:1633')
 
     return beeDebug.createPostageBatch('10000000000', 21)
   }

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -63,7 +63,7 @@ export async function waitForBlockchain(waitingIterations = 30): Promise<void> {
 }
 
 export async function waitForQueen(verifyQueenIsUp: () => Promise<boolean>, waitingIterations = 120): Promise<string> {
-  const beeDebug = new BeeDebug('http://127.0.0.1:1635')
+  const beeDebug = new BeeDebug('http://127.0.0.1:1633')
 
   for (let i = 0; i < waitingIterations; i++) {
     try {
@@ -97,7 +97,7 @@ export async function waitForWorkers(
   getStatus: () => Promise<AllStatus>,
   waitingIterations = 120,
 ): Promise<void> {
-  const beeDebug = new BeeDebug('http://127.0.0.1:1635')
+  const beeDebug = new BeeDebug('http://127.0.0.1:1633')
 
   const status = await getStatus()
   for (let i = 1; i <= workerCount; i++) {

--- a/test/integration/start.spec.ts
+++ b/test/integration/start.spec.ts
@@ -33,7 +33,7 @@ describe('start command', () => {
   beforeAll(() => {
     docker = new Dockerode()
     bee = new Bee('http://127.0.0.1:1633')
-    beeDebug = new BeeDebug('http://127.0.0.1:1635')
+    beeDebug = new BeeDebug('http://127.0.0.1:1633')
 
     // This will force Bee Factory to create
     process.env[ENV_ENV_PREFIX_KEY] = envPrefix


### PR DESCRIPTION
New Bee release will remove Bee Debug API endpoint `:1635` thereby all Debug API communication must be changed to the standard Bee API port `:1633`. 
Additionally, options for restricted API has been also removed. 