### PR TITLE
fix: add blockchain rpc endpoint option

### DIFF
--- a/orchestrator/builder/bee.sh
+++ b/orchestrator/builder/bee.sh
@@ -226,6 +226,7 @@ if [ -z "$QUEEN_CONTAINER_IN_DOCKER" ] || $EPHEMERAL ; then
         --api-addr=0.0.0.0:1633 \
         --swap-enable=$SWAP \
         --swap-endpoint="http://$SWARM_BLOCKCHAIN_NAME:9545" \
+        --blockchain-rpc-endpoint="http://$SWARM_BLOCKCHAIN_NAME:9545" \
         --swap-factory-address=$SWAP_FACTORY_ADDRESS \
         --postage-stamp-address=$POSTAGE_STAMP_ADDRESS \
         --price-oracle-address=$SWAP_PRICE_ORACLE_ADDRESS \
@@ -278,6 +279,7 @@ for i in $(seq 1 1 "$WORKERS"); do
           --api-addr=0.0.0.0:1633 \
           --swap-enable=$SWAP \
           --swap-endpoint="http://$SWARM_BLOCKCHAIN_NAME:9545" \
+          --blockchain-rpc-endpoint="http://$SWARM_BLOCKCHAIN_NAME:9545" \
           --swap-factory-address=$SWAP_FACTORY_ADDRESS \
           --postage-stamp-address=$POSTAGE_STAMP_ADDRESS \
           --price-oracle-address=$SWAP_PRICE_ORACLE_ADDRESS \

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -509,6 +509,7 @@ export class Docker {
       'swap-enable': 'true',
       mainnet: 'false',
       'swap-endpoint': `http://${this.blockchainName}:9545`,
+      'blockchain-rpc-endpoint': `http://${this.blockchainName}:9545`,
       'swap-factory-address': SWAP_FACTORY_ADDRESS,
       password: 'password',
       'postage-stamp-address': POSTAGE_STAMP_ADDRESS,


### PR DESCRIPTION
Updating from Bee 2.2 to 2.5 requires to set `blockchain-rpc-endpoint` option on start.